### PR TITLE
Make the desktop UI debuggable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ CODESIGN_APP_CERT=
 ifeq ($(ZT_OFFICIAL_RELEASE),1)
 	CODESIGN=codesign
 	CODESIGN_APP_CERT="Developer ID Application: ZeroTier, Inc (8ZD9JUCZ4V)"
+	CARGO_FLAGS=--release
+	CARGO_TARGET_DIR=release
+else
+	CARGO_FLAGS=
+	CARGO_TARGET_DIR=debug
 endif
 
 all:    $(MAINTARGET)
@@ -19,29 +24,29 @@ all:    $(MAINTARGET)
 windows: FORCE
 	make -C tray clean
 	make -C tray zt_lib
-	cargo build --release --target=x86_64-pc-windows-msvc
+	cargo build $(CARGO_FLAGS) --target=x86_64-pc-windows-msvc
 	make -C tray clean
 	make -C tray zt_lib WIN_32BIT=1
-	set "RUSTFLAGS=-C link-args=/SAFESEH:NO" && cargo build --release --target=i686-pc-windows-msvc
+	set "RUSTFLAGS=-C link-args=/SAFESEH:NO" && cargo build $(CARGO_FLAGS) --target=i686-pc-windows-msvc
 
 linux: FORCE
 	cd tray ; make clean
 	cd tray ; make zt_lib
-	cargo build --release
+	cargo build $(CARGO_FLAGS)
 
 mac: FORCE
 	cd tray ; make clean
 	cd tray ; make -j2 zt_lib
-	MACOSX_DEPLOYMENT_TARGET=10.13 cargo build --release --target=aarch64-apple-darwin
-	MACOSX_DEPLOYMENT_TARGET=10.13 cargo build --release --target=x86_64-apple-darwin
-	lipo -create target/aarch64-apple-darwin/release/zerotier_desktop_ui target/x86_64-apple-darwin/release/zerotier_desktop_ui -output target/release/zerotier_desktop_ui
+	MACOSX_DEPLOYMENT_TARGET=10.13 cargo build $(CARGO_FLAGS) --target=aarch64-apple-darwin
+	MACOSX_DEPLOYMENT_TARGET=10.13 cargo build $(CARGO_FLAGS) --target=x86_64-apple-darwin
+	lipo -create target/aarch64-apple-darwin/$(CARGO_TARGET_DIR)/zerotier_desktop_ui target/x86_64-apple-darwin/$(CARGO_TARGET_DIR)/zerotier_desktop_ui -output target/$(CARGO_TARGET_DIR)/zerotier_desktop_ui
 	make mac-assemble-app
 
 mac-assemble-app: FORCE
 	rm -rf ZeroTier.app
 	cp -av mac-app-template/ZeroTier.app .
 	mkdir -p ZeroTier.app/Contents/MacOS
-	cp -f target/release/zerotier_desktop_ui ZeroTier.app/Contents/MacOS/ZeroTier
+	cp -f target/$(CARGO_TARGET_DIR)/zerotier_desktop_ui ZeroTier.app/Contents/MacOS/ZeroTier
 	cp -f ui/dist/index.html ZeroTier.app/Contents/Resources/ui.html
 	cp -f ui/dist/dark.css ZeroTier.app/Contents/Resources/dark.css
 	cp -f ui/dist/light.css ZeroTier.app/Contents/Resources/light.css

--- a/tray/Makefile
+++ b/tray/Makefile
@@ -3,20 +3,35 @@ ifeq ($(OS),Windows_NT)
 	RM=del /q
 	LIB_NAME=zt_desktop_tray.lib
 	TRAY_LDFLAGS :=
-	ifeq ($(WIN_32BIT),1)
-		TRAY_CFLAGS := -O -DTRAY_WINAPI=1 -std=c99 -m32 -fno-exceptions
+	ifeq ($(ZT_OFFICIAL_RELEASE),1)
+		OPT_FLAGS := -O
 	else
-		TRAY_CFLAGS := -O -DTRAY_WINAPI=1 -std=c99 -m64 -fno-exceptions
+		OPT_FLAGS := -Og
+	endif
+	ifeq ($(WIN_32BIT),1)
+		TRAY_CFLAGS := $(OPT_FLAGS) -DTRAY_WINAPI=1 -std=c99 -m32 -fno-exceptions
+	else
+		TRAY_CFLAGS := $(OPT_FLAGS) -DTRAY_WINAPI=1 -std=c99 -m64 -fno-exceptions
 	endif
 else ifeq ($(shell uname -s),Linux)
 	RM=rm -f
 	LIB_NAME=libzt_desktop_tray.a
-	TRAY_CFLAGS := -O -DTRAY_APPINDICATOR=1 $(shell pkg-config --cflags appindicator3-0.1) -std=c99
+	ifeq ($(ZT_OFFICIAL_RELEASE),1)
+		OPT_FLAGS := -O
+	else
+		OPT_FLAGS := -Og
+	endif
+	TRAY_CFLAGS := $(OPT_FLAGS) -DTRAY_APPINDICATOR=1 $(shell pkg-config --cflags appindicator3-0.1) -std=c99
 	TRAY_LDFLAGS := $(shell pkg-config --libs appindicator3-0.1)
 else ifeq ($(shell uname -s),Darwin)
 	RM=rm -f
 	LIB_NAME=libzt_desktop_tray.a
-	TRAY_CFLAGS := -Os -arch x86_64 -arch arm64 -DTRAY_APPKIT=1 -std=c99 -mmacosx-version-min=10.13
+	ifeq ($(ZT_OFFICIAL_RELEASE),1)
+		OPT_FLAGS := -Os
+	else
+		OPT_FLAGS := -Og
+	endif
+	TRAY_CFLAGS := $(OPT_FLAGS) -arch x86_64 -arch arm64 -DTRAY_APPKIT=1 -std=c99 -mmacosx-version-min=10.13
 	TRAY_LDFLAGS := -framework Cocoa
 endif
 


### PR DESCRIPTION
It was impossible to build a debuggable binary from the Makefile.  Debug is now the default.  Release is built & signed with the `ZT_OFFICIAL_RELEASE` flag.