### PR TITLE
Fix for Issue #32

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1212,7 +1212,12 @@ fn main() {
                 }
             },
             "copy_authtoken" => { // invoked with elevated permissions to get the auth token and copy it locally
-                let _ = serviceclient::get_auth_token_and_port(false);
+                if args.len() < 3 {
+                    println!("FATAL: copy_authtoken requires additional argument");
+                    std::process::exit(1);
+                }
+
+                let _ = serviceclient::get_auth_token_and_port(false, &Ok(args[2].clone()));
             }
             _ => println!("FATAL: unrecognized mode: {}", args[1])
         }


### PR DESCRIPTION
patch serviceclient::get_auth_token_and_port() so that the home directory is specified externally to it.

Previously, it calculated the user home at the top of the function definition, but this caused issues when being run from non-Administrator accounts on Windows. The function would first be run as the non-Admin user.  The app detects that it doesn't have access to the system authtoken so it requests to elevate privileges and copy.  The issue arrises is that the destination path was re-calculated after running as an administrator so the target path of the copy was the administrator's home directory, not the initial user.  This patch sets the target home directory as a command line argument when running the copy_authtoken subcommand.