### PR TITLE
Transition to libaytana-appindicator3 from libappindicator3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To build native applications for Windows, just type `make`. This assumes that GN
 * gdk-3
 * gobject-2.0
 * glib-2.0
-* libappindicator3
+* libaytana-appindicator3
 
 # Directly Incorporated Third Party Code
 

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=gdk-3");
         println!("cargo:rustc-link-lib=dylib=gobject-2.0");
         println!("cargo:rustc-link-lib=dylib=glib-2.0");
-        println!("cargo:rustc-link-lib=dylib=appindicator3");
+        println!("cargo:rustc-link-lib=dylib=ayatana-appindicator3");
     }
 }

--- a/tray/Makefile
+++ b/tray/Makefile
@@ -21,8 +21,8 @@ else ifeq ($(shell uname -s),Linux)
 	else
 		OPT_FLAGS := -Og
 	endif
-	TRAY_CFLAGS := $(OPT_FLAGS) -DTRAY_APPINDICATOR=1 $(shell pkg-config --cflags appindicator3-0.1) -std=c99
-	TRAY_LDFLAGS := $(shell pkg-config --libs appindicator3-0.1)
+	TRAY_CFLAGS := $(OPT_FLAGS) -DTRAY_APPINDICATOR=1 $(shell pkg-config --cflags ayatana-appindicator3-0.1) -std=c99
+	TRAY_LDFLAGS := $(shell pkg-config --libs ayatana-appindicator3-0.1)
 else ifeq ($(shell uname -s),Darwin)
 	RM=rm -f
 	LIB_NAME=libzt_desktop_tray.a

--- a/tray/tray.h
+++ b/tray/tray.h
@@ -31,7 +31,7 @@ void tray_update(struct tray *tray);
 #if defined(TRAY_APPINDICATOR)
 
 #include <gtk/gtk.h>
-#include <libappindicator/app-indicator.h>
+#include <libayatana-appindicator/app-indicator.h>
 
 #define TRAY_APPINDICATOR_ID "tray-id"
 


### PR DESCRIPTION
libappindicator is practically unmaintained by canonical and a general
transition towards the community maintained libaytana-appindicator
has been going on for a while now (in ubuntu derivatives, debian :
https://bugs.launchpad.net/ubuntu/+source/libayatana-appindicator/+bug/1915695

This commit switches the linux build to using the community
provided `libaytana-appindicator3` and has been tested on:
ubuntu, pop-os and debian.
