### PR TITLE
Fix compile error on gcc14

### DIFF
--- a/libui-ng/unix/text.c
+++ b/libui-ng/unix/text.c
@@ -1,5 +1,6 @@
 // 9 april 2015
 #include "uipriv_unix.h"
+#include <strings.h> // for strcasecmp
 
 char *uiUnixStrdupText(const char *t)
 {

--- a/tray/zt_desktop_tray.c
+++ b/tray/zt_desktop_tray.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h> // for chmod
 
 #if defined (_WIN32) || defined (_WIN64)
 #define TRAY_WINAPI 1


### PR DESCRIPTION
Trivial includes missing for implicitly included methods